### PR TITLE
Add number classification logic and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^4.0.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.0.3",
+        "axios": "^1.7.9",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
       },
@@ -2183,6 +2185,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nestjs/axios": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.0.tgz",
+      "integrity": "sha512-1cB+Jyltu/uUPNQrpUimRHEQHrnQrpLzVj6dU3dgn6iDDDdahr10TgHFGTmw5VuJ9GzKZsCLDL78VSwJAs/9JQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "axios": "^1.3.1",
+        "rxjs": "^7.0.0"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.2.tgz",
@@ -4091,8 +4104,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/b4a": {
       "version": "1.6.7",
@@ -4900,7 +4923,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5226,7 +5248,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6223,6 +6244,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -6337,7 +6378,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -6362,7 +6402,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6372,7 +6411,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -9059,6 +9097,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.0.3",
+    "axios": "^1.7.9",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -1,22 +1,81 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { HttpModule } from '@nestjs/axios';
 
 describe('AppController', () => {
     let appController: AppController;
+    let appService: AppService;
 
     beforeEach(async () => {
         const app: TestingModule = await Test.createTestingModule({
+            imports: [HttpModule],
             controllers: [AppController],
             providers: [AppService],
         }).compile();
 
         appController = app.get<AppController>(AppController);
+        appService = app.get<AppService>(AppService);
     });
 
-    describe('root', () => {
-        it('should return "Hello World!"', () => {
-            expect(appController.getHello()).toBe('Hello World!');
+    describe('classify', () => {
+        it('should classify a prime number', async () => {
+            const result = await appController.classify('7');
+            expect(result).toEqual({
+                number: 7,
+                is_prime: true,
+                is_perfect: false,
+                properties: ['prime', 'odd'],
+                digit_sum: 7,
+                fun_fact: expect.any(String),
+            });
+        });
+
+        it('should classify a perfect number', async () => {
+            const result = await appController.classify('6');
+            expect(result).toEqual({
+                number: 6,
+                is_prime: false,
+                is_perfect: true,
+                properties: ['perfect', 'even'],
+                digit_sum: 6,
+                fun_fact: expect.any(String),
+            });
+        });
+
+        it('should classify an Armstrong number', async () => {
+            const result = await appController.classify('153');
+            expect(result).toEqual({
+                number: 153,
+                is_prime: false,
+                is_perfect: false,
+                properties: ['armstrong', 'odd'],
+                digit_sum: 9,
+                fun_fact: expect.any(String),
+            });
+        });
+
+        it('should classify an odd number', async () => {
+            const result = await appController.classify('9');
+            expect(result).toEqual({
+                number: 9,
+                is_prime: false,
+                is_perfect: false,
+                properties: ['odd'],
+                digit_sum: 9,
+                fun_fact: expect.any(String),
+            });
+        });
+
+        it('should return a bad request for invalid number', async () => {
+            try {
+                await appController.classify('invalid');
+            } catch (error) {
+                expect(error.response).toEqual({
+                    number: 'invalid',
+                    error: true,
+                });
+            }
         });
     });
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,19 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Query, BadRequestException } from '@nestjs/common';
 import { AppService } from './app.service';
 
 @Controller('api')
 export class AppController {
     constructor(private readonly appService: AppService) {}
 
-    @Get()
-    async classify() {
-        return await this.appService.classify();
+    @Get('classify-number')
+    async classify(@Query('number') number: string) {
+        const parsedNumber = parseInt(number, 10);
+        if (isNaN(parsedNumber)) {
+            throw new BadRequestException({
+                number,
+                error: true,
+            });
+        }
+        return await this.appService.classify(parsedNumber);
     }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,17 @@ import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { RequestLoggerMiddleware } from './request-logger/request-logger.middleware';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
-    imports: [],
+    imports: [
+        HttpModule.registerAsync({
+            useFactory: () => ({
+                timeout: 5000,
+                maxRedirects: 5,
+            }),
+        }),
+    ],
     controllers: [AppController],
     providers: [AppService],
 })

--- a/src/app.service.spec.ts
+++ b/src/app.service.spec.ts
@@ -60,15 +60,26 @@ describe('AppService', () => {
 
     describe('getProperties', () => {
         it('should return the correct properties', () => {
-            expect(service['getProperties'](true, false, false, 7)).toEqual(['prime', 'odd']);
-            expect(service['getProperties'](false, true, false, 6)).toEqual(['perfect', 'even']);
-            expect(service['getProperties'](false, false, true, 153)).toEqual(['armstrong', 'odd']);
+            expect(service['getProperties'](true, false, false, 7)).toEqual([
+                'prime',
+                'odd',
+            ]);
+            expect(service['getProperties'](false, true, false, 6)).toEqual([
+                'perfect',
+                'even',
+            ]);
+            expect(service['getProperties'](false, false, true, 153)).toEqual([
+                'armstrong',
+                'odd',
+            ]);
         });
     });
 
     describe('getFunFact', () => {
         it('should return a fun fact', async () => {
-            jest.spyOn(service['httpService'], 'get').mockReturnValue(of({ data: 'fun fact' }));
+            jest.spyOn(service['httpService'], 'get').mockReturnValue(
+                of({ data: 'fun fact' }),
+            );
             const funFact = await service['getFunFact'](7);
             expect(funFact).toBe('fun fact');
         });

--- a/src/app.service.spec.ts
+++ b/src/app.service.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpModule } from '@nestjs/axios';
+import { AppService } from './app.service';
+import { of } from 'rxjs';
+
+describe('AppService', () => {
+    let service: AppService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            imports: [HttpModule],
+            providers: [AppService],
+        }).compile();
+
+        service = module.get<AppService>(AppService);
+    });
+
+    describe('isPrime', () => {
+        it('should return true for prime numbers', () => {
+            expect(service['isPrime'](7)).toBe(true);
+            expect(service['isPrime'](13)).toBe(true);
+        });
+
+        it('should return false for non-prime numbers', () => {
+            expect(service['isPrime'](4)).toBe(false);
+            expect(service['isPrime'](9)).toBe(false);
+        });
+    });
+
+    describe('isPerfect', () => {
+        it('should return true for perfect numbers', () => {
+            expect(service['isPerfect'](6)).toBe(true);
+            expect(service['isPerfect'](28)).toBe(true);
+        });
+
+        it('should return false for non-perfect numbers', () => {
+            expect(service['isPerfect'](5)).toBe(false);
+            expect(service['isPerfect'](10)).toBe(false);
+        });
+    });
+
+    describe('isArmstrong', () => {
+        it('should return true for Armstrong numbers', () => {
+            expect(service['isArmstrong'](153)).toBe(true);
+            expect(service['isArmstrong'](370)).toBe(true);
+        });
+
+        it('should return false for non-Armstrong numbers', () => {
+            expect(service['isArmstrong'](123)).toBe(false);
+            expect(service['isArmstrong'](200)).toBe(false);
+        });
+    });
+
+    describe('calculateDigitSum', () => {
+        it('should return the correct digit sum', () => {
+            expect(service['calculateDigitSum'](123)).toBe(6);
+            expect(service['calculateDigitSum'](456)).toBe(15);
+        });
+    });
+
+    describe('getProperties', () => {
+        it('should return the correct properties', () => {
+            expect(service['getProperties'](true, false, false, 7)).toEqual(['prime', 'odd']);
+            expect(service['getProperties'](false, true, false, 6)).toEqual(['perfect', 'even']);
+            expect(service['getProperties'](false, false, true, 153)).toEqual(['armstrong', 'odd']);
+        });
+    });
+
+    describe('getFunFact', () => {
+        it('should return a fun fact', async () => {
+            jest.spyOn(service['httpService'], 'get').mockReturnValue(of({ data: 'fun fact' }));
+            const funFact = await service['getFunFact'](7);
+            expect(funFact).toBe('fun fact');
+        });
+    });
+});

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,10 +1,69 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, HttpService } from '@nestjs/common';
 
 @Injectable()
 export class AppService {
-    async classify() {
+    constructor(private readonly httpService: HttpService) {}
+
+    async classify(number: number) {
+        const isPrime = this.isPrime(number);
+        const isPerfect = this.isPerfect(number);
+        const isArmstrong = this.isArmstrong(number);
+        const digitSum = this.calculateDigitSum(number);
+        const properties = this.getProperties(isPrime, isPerfect, isArmstrong, number);
+
+        const funFact = await this.getFunFact(number);
+
         return {
-            message: 'this is a placeholder',
+            number,
+            is_prime: isPrime,
+            is_perfect: isPerfect,
+            properties,
+            digit_sum: digitSum,
+            fun_fact: funFact,
         };
+    }
+
+    private isPrime(number: number): boolean {
+        if (number <= 1) return false;
+        for (let i = 2; i < number; i++) {
+            if (number % i === 0) return false;
+        }
+        return true;
+    }
+
+    private isPerfect(number: number): boolean {
+        let sum = 0;
+        for (let i = 1; i < number; i++) {
+            if (number % i === 0) sum += i;
+        }
+        return sum === number;
+    }
+
+    private isArmstrong(number: number): boolean {
+        const digits = number.toString().split('');
+        const sum = digits.reduce((acc, digit) => acc + Math.pow(parseInt(digit), digits.length), 0);
+        return sum === number;
+    }
+
+    private calculateDigitSum(number: number): number {
+        return number
+            .toString()
+            .split('')
+            .reduce((acc, digit) => acc + parseInt(digit), 0);
+    }
+
+    private getProperties(isPrime: boolean, isPerfect: boolean, isArmstrong: boolean, number: number): string[] {
+        const properties = [];
+        if (isPrime) properties.push('prime');
+        if (isPerfect) properties.push('perfect');
+        if (isArmstrong) properties.push('armstrong');
+        if (number % 2 === 0) properties.push('even');
+        else properties.push('odd');
+        return properties;
+    }
+
+    private async getFunFact(number: number): Promise<string> {
+        const response = await this.httpService.get(`http://numbersapi.com/${number}`).toPromise();
+        return response.data;
     }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -68,7 +68,7 @@ export class AppService {
         isArmstrong: boolean,
         number: number,
     ): string[] {
-        const properties = [];
+        const properties: string[] = [];
         if (isPrime) properties.push('prime');
         if (isPerfect) properties.push('perfect');
         if (isArmstrong) properties.push('armstrong');
@@ -77,10 +77,13 @@ export class AppService {
         return properties;
     }
 
-    private async getFunFact(number: number): Promise<AxiosResponse<string>> {
+    private async getFunFact(number: number): Promise<string> {
         const response = await this.httpService
             .get(`http://numbersapi.com/${number}`)
             .toPromise();
+        if (!response) {
+            throw new Error('Failed to fetch fun fact');
+        }
         return response.data;
     }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, HttpService } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class AppService {
@@ -9,7 +10,12 @@ export class AppService {
         const isPerfect = this.isPerfect(number);
         const isArmstrong = this.isArmstrong(number);
         const digitSum = this.calculateDigitSum(number);
-        const properties = this.getProperties(isPrime, isPerfect, isArmstrong, number);
+        const properties = this.getProperties(
+            isPrime,
+            isPerfect,
+            isArmstrong,
+            number,
+        );
 
         const funFact = await this.getFunFact(number);
 
@@ -41,7 +47,10 @@ export class AppService {
 
     private isArmstrong(number: number): boolean {
         const digits = number.toString().split('');
-        const sum = digits.reduce((acc, digit) => acc + Math.pow(parseInt(digit), digits.length), 0);
+        const sum = digits.reduce(
+            (acc, digit) => acc + Math.pow(parseInt(digit), digits.length),
+            0,
+        );
         return sum === number;
     }
 
@@ -52,7 +61,12 @@ export class AppService {
             .reduce((acc, digit) => acc + parseInt(digit), 0);
     }
 
-    private getProperties(isPrime: boolean, isPerfect: boolean, isArmstrong: boolean, number: number): string[] {
+    private getProperties(
+        isPrime: boolean,
+        isPerfect: boolean,
+        isArmstrong: boolean,
+        number: number,
+    ): string[] {
         const properties = [];
         if (isPrime) properties.push('prime');
         if (isPerfect) properties.push('perfect');
@@ -63,7 +77,9 @@ export class AppService {
     }
 
     private async getFunFact(number: number): Promise<string> {
-        const response = await this.httpService.get(`http://numbersapi.com/${number}`).toPromise();
+        const response = await this.httpService
+            .get(`http://numbersapi.com/${number}`)
+            .toPromise();
         return response.data;
     }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,5 +1,6 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
+import { AxiosResponse } from 'axios';
 
 @Injectable()
 export class AppService {
@@ -76,7 +77,7 @@ export class AppService {
         return properties;
     }
 
-    private async getFunFact(number: number): Promise<string> {
+    private async getFunFact(number: number): Promise<AxiosResponse<string>> {
         const response = await this.httpService
             .get(`http://numbersapi.com/${number}`)
             .toPromise();

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -22,4 +22,70 @@ describe('AppController (e2e)', () => {
             .expect(200)
             .expect('Hello World!');
     });
+
+    it('/api/classify-number (GET) - valid prime number', () => {
+        return request(app.getHttpServer())
+            .get('/api/classify-number?number=7')
+            .expect(200)
+            .expect({
+                number: 7,
+                is_prime: true,
+                is_perfect: false,
+                properties: ['prime', 'odd'],
+                digit_sum: 7,
+                fun_fact: expect.any(String),
+            });
+    });
+
+    it('/api/classify-number (GET) - valid perfect number', () => {
+        return request(app.getHttpServer())
+            .get('/api/classify-number?number=6')
+            .expect(200)
+            .expect({
+                number: 6,
+                is_prime: false,
+                is_perfect: true,
+                properties: ['perfect', 'even'],
+                digit_sum: 6,
+                fun_fact: expect.any(String),
+            });
+    });
+
+    it('/api/classify-number (GET) - valid Armstrong number', () => {
+        return request(app.getHttpServer())
+            .get('/api/classify-number?number=153')
+            .expect(200)
+            .expect({
+                number: 153,
+                is_prime: false,
+                is_perfect: false,
+                properties: ['armstrong', 'odd'],
+                digit_sum: 9,
+                fun_fact: expect.any(String),
+            });
+    });
+
+    it('/api/classify-number (GET) - valid odd number', () => {
+        return request(app.getHttpServer())
+            .get('/api/classify-number?number=9')
+            .expect(200)
+            .expect({
+                number: 9,
+                is_prime: false,
+                is_perfect: false,
+                properties: ['odd'],
+                digit_sum: 9,
+                fun_fact: expect.any(String),
+            });
+    });
+
+    it('/api/classify-number (GET) - invalid number', () => {
+        return request(app.getHttpServer())
+            .get('/api/classify-number?number=invalid')
+            .expect(400)
+            .expect({
+                number: 'invalid',
+                error: true,
+            });
+    });
 });


### PR DESCRIPTION
Fixes #5

Implement number classification logic in the app service and add corresponding tests.

* **App Service (`src/app.service.ts`)**
  - Implement the `classify` method to classify numbers and return properties.
  - Add helper methods to check if a number is prime, perfect, Armstrong, and calculate digit sum.
  - Fetch fun fact from the numbers API and include it in the response.

* **App Controller (`src/app.controller.ts`)**
  - Update the `classify` method to accept a number parameter.
  - Call the `classify` method from `AppService` with the number parameter.
  - Return the classified number properties in the response.

* **App Controller Tests (`src/app.controller.spec.ts`)**
  - Add tests for the `classify` method in `AppController`.
  - Test various cases including prime, perfect, Armstrong, and odd numbers.
  - Test for invalid number input and ensure it returns a bad request.

* **End-to-End Tests (`test/app.e2e-spec.ts`)**
  - Update the e2e tests to cover the number classification logic.
  - Test the endpoint `/api/classify-number` with valid and invalid inputs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/classify-number/pull/6?shareId=27e60aca-a84e-4b9f-92d4-be03a8c3d9c0).