### PR TITLE
Fix mock return value in app.service.spec.ts

### DIFF
--- a/src/app.service.spec.ts
+++ b/src/app.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { HttpModule } from '@nestjs/axios';
 import { AppService } from './app.service';
 import { of } from 'rxjs';
+import { AxiosResponse } from 'axios';
 
 describe('AppService', () => {
     let service: AppService;
@@ -68,7 +69,14 @@ describe('AppService', () => {
 
     describe('getFunFact', () => {
         it('should return a fun fact', async () => {
-            jest.spyOn(service['httpService'], 'get').mockReturnValue(of({ data: 'fun fact' }));
+            const mockResponse: AxiosResponse<unknown, unknown> = {
+                data: 'fun fact',
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            };
+            jest.spyOn(service['httpService'], 'get').mockReturnValue(of(mockResponse));
             const funFact = await service['getFunFact'](7);
             expect(funFact).toBe('fun fact');
         });


### PR DESCRIPTION
Modify the `jest.spyOn` mockReturnValue call in `src/app.service.spec.ts` to return an `Observable<AxiosResponse<unknown, unknown>>`.

* Import `AxiosResponse` from 'axios'.
* Create a `mockResponse` object with the required properties: `data`, `status`, `statusText`, `headers`, and `config`.
* Update the `jest.spyOn` mockReturnValue call to return `of(mockResponse)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/classify-number/pull/8?shareId=00964da9-2876-48fc-9309-60466bf763de).