### PR TITLE
Fix test suite in app.service.spec.ts

### DIFF
--- a/src/app.service.spec.ts
+++ b/src/app.service.spec.ts
@@ -74,7 +74,9 @@ describe('AppService', () => {
                 status: 200,
                 statusText: 'OK',
                 headers: {},
-                config: {},
+                config: {
+                    headers: {},
+                },
             };
             jest.spyOn(service['httpService'], 'get').mockReturnValue(of(mockResponse));
             const funFact = await service['getFunFact'](7);


### PR DESCRIPTION
Add 'headers' property to the `config` object in the mock response in `src/app.service.spec.ts`.

* Modify the `config` object to include an empty 'headers' property.
* Ensure the test suite runs without TypeScript errors related to the missing 'headers' property.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/classify-number/pull/9?shareId=364848aa-593b-469d-a0dd-158544e43938).