### PR TITLE
Fix TypeScript errors in app.service.ts

### DIFF
--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -68,7 +68,7 @@ export class AppService {
         isArmstrong: boolean,
         number: number,
     ): string[] {
-        const properties = [];
+        const properties: string[] = [];
         if (isPrime) properties.push('prime');
         if (isPerfect) properties.push('perfect');
         if (isArmstrong) properties.push('armstrong');
@@ -77,10 +77,13 @@ export class AppService {
         return properties;
     }
 
-    private async getFunFact(number: number): Promise<AxiosResponse<string>> {
+    private async getFunFact(number: number): Promise<string> {
         const response = await this.httpService
             .get(`http://numbersapi.com/${number}`)
             .toPromise();
+        if (!response) {
+            throw new Error('Failed to fetch fun fact');
+        }
         return response.data;
     }
 }


### PR DESCRIPTION
Fix TypeScript errors related to argument types and possibly undefined 'response'.

* Explicitly type the `properties` array as `string[]` in the `getProperties` method.
* Check if `response` is undefined before accessing `response.data` in the `getFunFact` method.
* Throw an error if `response` is undefined in the `getFunFact` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/classify-number/pull/11?shareId=c98e1fa5-3318-41c4-8c4c-073ab10c605c).