### PR TITLE
Fix tests for classifying numbers

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -25,7 +25,7 @@ describe('AppController', () => {
                 number: 7,
                 is_prime: true,
                 is_perfect: false,
-                properties: ['prime', 'odd'],
+                properties: ['prime', 'armstrong', 'odd'],
                 digit_sum: 7,
                 fun_fact: expect.any(String),
             });
@@ -37,7 +37,7 @@ describe('AppController', () => {
                 number: 6,
                 is_prime: false,
                 is_perfect: true,
-                properties: ['perfect', 'even'],
+                properties: ['perfect', 'armstrong', 'even'],
                 digit_sum: 6,
                 fun_fact: expect.any(String),
             });
@@ -61,7 +61,7 @@ describe('AppController', () => {
                 number: 9,
                 is_prime: false,
                 is_perfect: false,
-                properties: ['odd'],
+                properties: ['armstrong', 'odd'],
                 digit_sum: 9,
                 fun_fact: expect.any(String),
             });

--- a/src/app.service.spec.ts
+++ b/src/app.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { HttpModule } from '@nestjs/axios';
 import { AppService } from './app.service';
 import { of } from 'rxjs';
+import { AxiosResponse } from 'axios';
 
 describe('AppService', () => {
     let service: AppService;
@@ -78,7 +79,7 @@ describe('AppService', () => {
     describe('getFunFact', () => {
         it('should return a fun fact', async () => {
             jest.spyOn(service['httpService'], 'get').mockReturnValue(
-                of({ data: 'fun fact' }),
+                of({ data: 'fun fact' } as AxiosResponse<{ data: string }>),
             );
             const funFact = await service['getFunFact'](7);
             expect(funFact).toBe('fun fact');

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -78,7 +78,7 @@ export class AppService {
     }
 
     private async getFunFact(number: number): Promise<string> {
-        const response = await this.httpService
+        const response: AxiosResponse<string> = await this.httpService
             .get(`http://numbersapi.com/${number}`)
             .toPromise();
         if (!response) {


### PR DESCRIPTION
Fix tests for classifying numbers and update type handling in `getFunFact`.

* **src/app.service.spec.ts**
  - Import `AxiosResponse` from `axios`.
  - Update the `getFunFact` test to return an `AxiosResponse` type.
  - Mock the `getFunFact` method to return an `AxiosResponse` type.

* **src/app.controller.spec.ts**
  - Update the expected results to include the "armstrong" property for prime, perfect, and odd numbers.

* **src/app.service.ts**
  - Update the `getFunFact` method to return an `AxiosResponse` type.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/classify-number/pull/12?shareId=c5217c4a-622c-4cd8-88f5-bd98ee016853).