### PR TITLE
Add Swagger API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,12 @@ docker run -p 3000:3000 classify-number
 ```sh
 docker-compose up
 ```
+
+## Swagger API Documentation
+
+The API documentation is available via Swagger. To access the Swagger UI, follow these steps:
+
+1. Start the application using one of the Docker instructions above.
+2. Open your web browser and navigate to `http://localhost:3000`.
+
+You will see the Swagger UI, which provides detailed information about the API endpoints, request parameters, and response formats.

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,13 +1,20 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { AppService } from './app.service';
 import { Logger, BadRequestException } from '@nestjs/common';
+import { ApiTags, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { ClassifyNumberResponseDto } from './dto/classify-number-response.dto';
+import { BadRequestResponseDto } from './dto/bad-request-response.dto';
 
+@ApiTags('classify-number')
 @Controller('api')
 export class AppController {
     constructor(private readonly appService: AppService) {}
     logger = new Logger(AppController.name);
 
     @Get('classify-number')
+    @ApiQuery({ name: 'number', required: true, type: String })
+    @ApiResponse({ status: 200, description: 'Successful response', type: ClassifyNumberResponseDto })
+    @ApiResponse({ status: 400, description: 'Invalid number parameter', type: BadRequestResponseDto })
     async classify(@Query('number') number: string) {
         const parsedNumber = parseInt(number, 10);
         if (isNaN(parsedNumber)) {

--- a/src/dto/bad-request-response.dto.ts
+++ b/src/dto/bad-request-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BadRequestResponseDto {
+    @ApiProperty()
+    number: string;
+
+    @ApiProperty()
+    error: boolean;
+}

--- a/src/dto/classify-number-response.dto.ts
+++ b/src/dto/classify-number-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ClassifyNumberResponseDto {
+    @ApiProperty()
+    number: number;
+
+    @ApiProperty()
+    is_prime: boolean;
+
+    @ApiProperty()
+    is_perfect: boolean;
+
+    @ApiProperty()
+    digit_sum: number;
+
+    @ApiProperty()
+    fun_fact: string;
+
+    @ApiProperty()
+    properties: string[];
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,8 @@ import { NestFactory } from '@nestjs/core';
 import { ConsoleLogger } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { ClassifyNumberResponseDto } from './dto/classify-number-response.dto';
+import { BadRequestResponseDto } from './dto/bad-request-response.dto';
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule, {
@@ -19,7 +21,9 @@ async function bootstrap() {
         )
         .setVersion('1.0')
         .build();
-    const document = SwaggerModule.createDocument(app, config);
+    const document = SwaggerModule.createDocument(app, config, {
+        extraModels: [ClassifyNumberResponseDto, BadRequestResponseDto],
+    });
     SwaggerModule.setup('', app, document);
 
     await app.listen(process.env.PORT ?? 3000);


### PR DESCRIPTION
Fixes #26

Add Swagger API documentation to the project.

* **src/app.controller.ts**
  - Add `@ApiTags('classify-number')` decorator to the `AppController` class.
  - Add `@ApiQuery`, `@ApiResponse` decorators to the `classify` method for documenting query parameters and responses.

* **src/main.ts**
  - Import `ClassifyNumberResponseDto` and `BadRequestResponseDto`.
  - Update Swagger setup to include these DTOs in the API documentation.

* **src/dto/classify-number-response.dto.ts**
  - Create a new file to define the `ClassifyNumberResponseDto` class with properties: `number`, `is_prime`, `is_perfect`, `digit_sum`, `fun_fact`, and `properties`.

* **src/dto/bad-request-response.dto.ts**
  - Create a new file to define the `BadRequestResponseDto` class with properties: `number` and `error`.

* **README.md**
  - Add a section about accessing the Swagger API documentation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/classify-number/pull/27?shareId=0f0fa5b4-9a98-42dd-991f-2fc673d538a2).