### PR TITLE
Add npm run build command step to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN npm install
 
 COPY . .
 
+RUN npm run build
+
 EXPOSE 3000
 
 CMD ["npm", "run", "start:prod"]


### PR DESCRIPTION
Fixes #29

Add `npm run build` step to `Dockerfile`.

* Add `RUN npm run build` after the `COPY . .` instruction.
* Ensure the `RUN npm run build` step is before the `EXPOSE 3000` instruction.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/classify-number/pull/30?shareId=5d4f772a-19b3-4ba4-990a-fc603c7055e2).