### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build:


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change removes the version specification for the Docker Compose file.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-L2): Removed the version specification line (`version: '3.8'`).