### PR TITLE
Fix digit sum calculation for negative numbers

### DIFF
--- a/src/app.service.spec.ts
+++ b/src/app.service.spec.ts
@@ -74,6 +74,14 @@ describe('AppService', () => {
             const result2 = await service.classify(456);
             expect(result2).toHaveProperty('digit_sum', 15);
         });
+
+        it('should handle negative numbers', async () => {
+            const result = await service.classify(-123);
+            expect(result).toHaveProperty('digit_sum', 6);
+
+            const result2 = await service.classify(-456);
+            expect(result2).toHaveProperty('digit_sum', 15);
+        });
     });
 
     describe('properties', () => {

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -86,9 +86,9 @@ export class AppService {
             number,
             is_prime: this.isPrime(number),
             is_perfect: this.isPerfect(number),
+            properties: this.properties(number),
             digit_sum: this.digitSum(number),
             fun_fact: funFact,
-            properties: this.properties(number),
         };
     }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -29,7 +29,7 @@ export class AppService {
     }
 
     digitSum(number: number): number {
-        return number
+        return Math.abs(number)
             .toString()
             .split('')
             .reduce((sum, digit) => sum + parseInt(digit, 10), 0);


### PR DESCRIPTION
Fixes #35

Update `digitSum` method to use absolute value and add test cases for negative numbers.

* **src/app.service.ts**
  - Update `digitSum` method to use `Math.abs` to handle negative numbers.

* **src/app.service.spec.ts**
  - Add test cases for negative numbers in `classify` method to ensure correct digit sum calculation.
