### PR TITLE
Fix error response

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -17,7 +17,7 @@ export class AppController {
     logger = new Logger(AppController.name);
 
     @Get('classify-number')
-    @ApiQuery({ name: 'number', required: true, type: String })
+    @ApiQuery({ name: 'number', required: false, type: String })
     @ApiOkResponse({
         description: 'Successful response',
         type: ClassifyNumberResponseDto,
@@ -26,11 +26,18 @@ export class AppController {
         description: 'Invalid number parameter',
         type: BadRequestResponseDto,
     })
-    async classify(@Query('number') number: string) {
+    async classify(@Query('number') number?: string) {
+        if (!number) {
+            throw new BadRequestException({
+                number: '',
+                error: true,
+            });
+        }
+
         const parsedNumber = parseInt(number, 10);
         if (isNaN(parsedNumber)) {
             throw new BadRequestException({
-                number: 'alphabet',
+                number: number,
                 error: true,
             });
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,16 @@ async function bootstrap() {
             'API that takes a number and returns an interesting mathematical properties about it, along with a fun fact.',
         )
         .setVersion('1.0')
+        .addResponse('400', {
+            description: 'Invalid number parameter',
+            content: {
+                'application/json': {
+                    schema: {
+                        $ref: '#/components/schemas/BadRequestResponseDto',
+                    },
+                },
+            },
+        })
         .build();
     const document = SwaggerModule.createDocument(app, config, {
         extraModels: [ClassifyNumberResponseDto, BadRequestResponseDto],

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -36,9 +36,20 @@ describe('AppController (e2e)', () => {
             .expect(400)
             .expect((res) => {
                 expect(res.body).toEqual({
-                    statusCode: 400,
-                    message: 'Invalid number parameter',
-                    error: 'Bad Request',
+                    error: true,
+                    number: 'invalid',
+                });
+            });
+    });
+
+    it('/api/classify-number (GET) - missing query parameter', () => {
+        return request(app.getHttpServer())
+            .get('/api/classify-number')
+            .expect(400)
+            .expect((res) => {
+                expect(res.body).toEqual({
+                    error: true,
+                    number: '',
                 });
             });
     });


### PR DESCRIPTION
Fixes #38

Update error response and Swagger documentation for invalid and missing query parameters.

* **src/app.controller.ts**
  - Update the error response to set the `number` field to the provided invalid input.
  - Add a check for missing query parameter and return `{"error":true,"number":""}` with status code 400.

* **src/main.ts**
  - Update the Swagger documentation to reflect the required 400 status code for invalid numbers.

* **test/app.e2e-spec.ts**
  - Update the test for invalid number to expect the `number` field to be the provided invalid input.
  - Add a test for missing query parameter to expect `{"error":true,"number":""}` with status code 400.

