### PR TITLE
refactor(app-service): reorder armstrong number check in properties m…

### DIFF
--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -46,13 +46,13 @@ export class AppService {
 
     properties(number: number): string[] {
         const properties: string[] = [];
+        if (this.isArmstrong(number)) {
+            properties.push('armstrong');
+        }
         if (number % 2 === 0) {
             properties.push('even');
         } else {
             properties.push('odd');
-        }
-        if (this.isArmstrong(number)) {
-            properties.push('armstrong');
         }
         return properties;
     }


### PR DESCRIPTION

This pull request includes a change to the `properties` method in the `AppService` class to ensure that the 'armstrong' property is checked before the 'even' or 'odd' properties.

Codebase modification:

* [`src/app.service.ts`](diffhunk://#diff-a4ac7efdbcfcdcc01a90d433ec3dabf1d88ab4bffbe3dc88f13db54db2e051f5R49-L56): Moved the check for Armstrong numbers to occur before the checks for even or odd numbers in the `properties` method.