### PR TITLE
Fix bad request exception for non-numeric inputs

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -27,13 +27,13 @@ export class AppController {
         type: BadRequestResponseDto,
     })
     async classify(@Query('number') number: string) {
-        const parsedNumber = parseInt(number, 10);
-        if (isNaN(parsedNumber)) {
+        if (!/^\d+$/.test(number)) {
             throw new BadRequestException({ 
                 error: true,
                 number: number,
             });
         }
+        const parsedNumber = parseInt(number, 10);
         return await this.appService.classify(parsedNumber);
     }
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -42,4 +42,43 @@ describe('AppController (e2e)', () => {
                 });
             });
     });
+
+    it('/api/classify-number (GET) - invalid number with letters', () => {
+        return request(app.getHttpServer())
+            .get('/api/classify-number?number=2abc')
+            .expect(400)
+            .expect((res) => {
+                expect(res.body).toEqual({
+                    statusCode: 400,
+                    message: 'Invalid number parameter',
+                    error: 'Bad Request',
+                });
+            });
+    });
+
+    it('/api/classify-number (GET) - invalid number with letters at the end', () => {
+        return request(app.getHttpServer())
+            .get('/api/classify-number?number=23c')
+            .expect(400)
+            .expect((res) => {
+                expect(res.body).toEqual({
+                    statusCode: 400,
+                    message: 'Invalid number parameter',
+                    error: 'Bad Request',
+                });
+            });
+    });
+
+    it('/api/classify-number (GET) - invalid number with only letters', () => {
+        return request(app.getHttpServer())
+            .get('/api/classify-number?number=abc')
+            .expect(400)
+            .expect((res) => {
+                expect(res.body).toEqual({
+                    statusCode: 400,
+                    message: 'Invalid number parameter',
+                    error: 'Bad Request',
+                });
+            });
+    });
 });


### PR DESCRIPTION
Fixes #44

Update `classify` method in `src/app.controller.ts` to validate input strictly as a number.

* Modify the `classify` method to check if the input contains only numeric characters using a regular expression.
* Throw a `BadRequestException` if the input contains non-numeric characters.
* Add test cases in `test/app.e2e-spec.ts` for inputs like 'abc', '2abc', '23c' to check for `BadRequestException`.

