### PR TITLE
Fix classify number function to handle negative numbers

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -27,7 +27,7 @@ export class AppController {
         type: BadRequestResponseDto,
     })
     async classify(@Query('number') number: string) {
-        if (!/^\d+$/.test(number)) {
+        if (!/^-?\d+$/.test(number)) {
             throw new BadRequestException({ 
                 error: true,
                 number: number,

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -22,12 +22,12 @@ export class AppService {
     isPerfect(number: number): boolean {
         if (number <= 0) return false;
         let sum = 0;
-        for (let i = 1; i <= number / 2; i++) {
+        for (let i = 1; i <= Math.abs(number) / 2; i++) {
             if (number % i === 0) {
                 sum += i;
             }
         }
-        return sum === number;
+        return sum === Math.abs(number);
     }
 
     digitSum(number: number): number {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -24,7 +24,25 @@ describe('AppController (e2e)', () => {
                 expect(res.body).toEqual({
                     number: 7,
                     is_prime: true,
+                    is_perfect: false,
+                    properties: ['odd'],
                     digit_sum: 7,
+                    fun_fact: expect.any(String),
+                });
+            });
+    });
+
+    it('/api/classify-number (GET) - negative number', () => {
+        return request(app.getHttpServer())
+            .get('/api/classify-number?number=-5')
+            .expect(200)
+            .expect((res) => {
+                expect(res.body).toEqual({
+                    number: -5,
+                    is_prime: false,
+                    is_perfect: false,
+                    properties: ['odd'],
+                    digit_sum: 5,
                     fun_fact: expect.any(String),
                 });
             });


### PR DESCRIPTION
Fixes #46

Update `classify` method in `src/app.controller.ts` to handle negative numbers correctly.

* Modify the regular expression in the `classify` method to allow negative numbers.
* Update the `isPerfect` method in `src/app.service.ts` to handle negative numbers by using the absolute value of the number.
* Add a test case for negative numbers in `test/app.e2e-spec.ts`.

